### PR TITLE
better convention, add security

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,20 @@ If your Postman request is working, great! You'll notice that the Siri client is
 * If the request's method is OPTIONS (this is the call the browser makes to check if the site we're getting data from allows cross-origin requests), return the following header/response:
 
 ```javascript
-res.writeHead(200, {
-  'Connection': 'close',
-  'Content-Type': 'application/json',
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'OPTIONS, GET, POST',
-  'Access-Control-Allow-Headers': 'Origin, X-Requested-With, Content-Type, Accept'
-});
+res.statusCode = 200;
+
+res.setHeader('Content-Type', 'application/json');
+
+// Allow any website to access this API
+res.setHeader('Access-Control-Allow-Origin', '*');
+res.setHeader('Access-Control-Allow-Methods', 'OPTIONS, GET, POST');
+res.setHeader('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
+
+// Don’t allow scripts or iframes execution from domains we don't trust
+res.setHeader('X-XSS-Protection', '1; mode=block');
+res.setHeader('X-Frame-Options', 'SAMEORIGIN');
+res.setHeader('Content-Security-Policy', "default-src 'self' devmountain.github.io");
+
 res.end();
 ```
 


### PR DESCRIPTION
use res.setHeader, not res.writeHead

Also, if they're going to use CORS, they really had better learn the minimal CSP header as well. It's dangerous not to.
